### PR TITLE
SOPORTE: SOLICITUDES PERMITIDAS A LA API CORE DE AURORA

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -57,7 +57,7 @@ class RouteServiceProvider extends ServiceProvider
     protected function configureRateLimiting()
     {
         RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by(optional($request->user())->id ?: $request->ip());
+            return Limit::perMinute(300)->by(optional($request->user())->id ?: $request->ip());
         });
     }
 }


### PR DESCRIPTION
Se modificó la cantidad de solicitudes permitidas por minuto a la api core de 60 a 300